### PR TITLE
Add shouldGetAll to `.identify()`, correct documentation

### DIFF
--- a/docs/chord.md
+++ b/docs/chord.md
@@ -13,6 +13,12 @@ Returns a [Chord](#chord-object) object given an argument list of [Note](note.md
 ### <a name="module-identify-array"></a> identifyArray `.identifyArray([notes])`
 Invokes `.identify()` with the contents of `[notes]` as its arguments.
 
+### <a name="module-get-possible-chord-names"></a> getPossibleChordNames `.getPossibleChordNames(notes...)`
+Returns a list of chord names given an argument list of [Note](note.md#note-object) objects or strings, ignoring octave numbers. Similar to `.identify(notes...)`, but returns all possible matches. Matches are sorted by how "reasonable" they are, with reasonable ones coming first in the list.
+
+### <a name="module-get-possible-chord-names-from-array"></a> getPossibleChordNamesFromArray `.getPossibleChordNamesFromArray([notes])`
+Invokes `.getPossibleChordNames()` with the contents of `[notes]` as its arguments.
+
 ### <a name="module-is-chord"></a> isChord `.isChord(obj)`
 Returns true if an object is a [Chord](#chord-object).
 

--- a/lib/chord.js
+++ b/lib/chord.js
@@ -304,7 +304,7 @@ var tryInversion = function (inversion) {
   };
 };
 
-var identify = function () {
+var getPossibleChords = function () {
   var notes = _.map(arguments, function (n) {
     return note.create(n);
   });
@@ -319,7 +319,31 @@ var identify = function () {
     };
   });
 
-  var results = _.map(inversions, tryInversion);
+  return _.chain(inversions)
+    .map(tryInversion)
+    .sortBy(function (r) {
+      return r.reasonable ? 0 : 1;
+    })
+    .uniq(false, function (r) {
+      return r.symbol;
+    })
+    .value();
+}
+
+var getPossibleChordNames = function () {
+  return getPossibleChords
+    .apply(this, arguments)
+    .map(function (n) {
+      return n.symbol
+    });
+};
+
+var getPossibleChordNamesFromArray = function (arr) {
+  return getPossibleChordNames.apply(this, arr);
+};
+
+var identify = function () {
+  var results = getPossibleChords.apply(this, arguments);
 
   // Look for a "reasonable" result
   var reasonable = _.find(results, function (obj) {
@@ -534,5 +558,7 @@ module.exports.isChord = function (chord) {
 
 module.exports.identify = identify;
 module.exports.identifyArray = identifyArray;
+module.exports.getPossibleChordNames = getPossibleChordNames;
+module.exports.getPossibleChordNamesFromArray = getPossibleChordNamesFromArray;
 module.exports.create = createChord;
 module.exports.Chord = Chord;

--- a/test/chord.test.js
+++ b/test/chord.test.js
@@ -166,6 +166,28 @@ describe('Chord', function () {
     });
   });
 
+  describe('#getPossibleChordNames', function () {
+    it('should find chord names', function () {
+      assert.deepEqual(chord.getPossibleChordNames('C', 'E', 'G'), ['C', 'Em/C', 'Gsus4/C']);
+      assert.deepEqual(chord.getPossibleChordNames('F#', 'A#', 'D#'), ['D#m/F#', 'F#6', 'A#sus4/F#']);
+    });
+
+    it('should return reasonable names first', function () {
+      assert.equal(chord.getPossibleChordNames('C', 'E', 'G')[0], 'C');
+    });
+
+    it('should only return unique matches', function () {
+      assert.equal(chord.getPossibleChordNames('C', 'C', 'E', 'G')[0], 'C');
+      assert.notEqual(chord.getPossibleChordNames('C', 'C', 'E', 'G')[1], 'C');
+    });
+  });
+
+  describe('#getPossibleChordNamesFromArray', function () {
+    it('should find chord names given an array', function () {
+      assert.deepEqual(chord.getPossibleChordNamesFromArray(['C', 'E', 'G']), ['C', 'Em/C', 'Gsus4/C']);
+    });
+  });
+
   describe('#identify', function () {
     it('should identify a chord', function () {
       assert.equal(chord.identify('C', 'E', 'G'), 'C');


### PR DESCRIPTION
Hi!

I, as in #2, also needed to get all of the names for a chord based on a set of notes. I decided to add a `shouldGetAll` option, which simply returns all of the inversions. This presented a small problem for `.identify(notes...)` which takes the notes from the argument list, as there is no room for the `shouldGetAll` argument in a way that makes sense. So I only implemented it for `.identifyArray(notes)`, and changed `.identify(notes...)` to be based off of it. I've also changed the documentation accordingly.

I don't know if you think this is the best approach or not. I'm welcome to suggestions, it's just the best and most compatible way to achieve something I needed. An alternative without the extra argument would be creating a `.identifyArrayAll()` method or similar.

One more thing — regardless of this change, the documentation incorrectly stated that `.identify()` returns a `Chord`, whereas it only returns a chord symbol. I've also corrected this in the edited documentation.

Looking forward to hearing what you think!