### PR TITLE
rubber-underpants chord.identify

### DIFF
--- a/lib/chord.js
+++ b/lib/chord.js
@@ -351,7 +351,7 @@ var identify = function () {
   });
 
   // Use reasonable result, default to root position
-  var chord = reasonable ? reasonable.symbol : results[0].symbol;
+  var chord = reasonable ? reasonable.symbol : (results[0] || {}).symbol;
 
   return chord;
 };

--- a/test/chord.test.js
+++ b/test/chord.test.js
@@ -261,6 +261,7 @@ describe('Chord', function () {
   describe('#identifyArray', function () {
     it('should identify a chord given an array', function () {
       assert.equal(chord.identifyArray(['C', 'E', 'G']), 'C');
+      assert.equal(chord.identifyArray([], undefined));
     });
   });
 


### PR DESCRIPTION
Calling `chord.identifyArray` with an empty array currently blows up. This change will cause it to return `undefined` instead. Thoughts?